### PR TITLE
Add paste overlay for invy and bank

### DIFF
--- a/src/main/java/com/geel/masteringmixology/Findings.java
+++ b/src/main/java/com/geel/masteringmixology/Findings.java
@@ -58,8 +58,10 @@ public class Findings {
      * Homogenize progress: 11329 0->15
      *
      * HERBS:
-     * 11332: Southwest herb?
-     *
+     * 11330: Northeast herb (GameObject ID: 55396)
+     * 11331: Southeast herb (GameObject ID: 55397)2
+     * 11332: Southwest herb (GameObject ID: 55398)
+     * 11333: Northwest herb (GameObject ID: 55399)
      *
      * --- OBJECTS ---
      *

--- a/src/main/java/com/geel/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/com/geel/masteringmixology/MasteringMixologyConfig.java
@@ -19,4 +19,24 @@ public interface MasteringMixologyConfig extends Config {
     default AlchemyBuilding prioritisedBuilding() {
         return AlchemyBuilding.NONE;
     }
+
+    @ConfigItem(
+            position = 1,
+            keyName = "inventoryOverlay",
+            name = "Herbs In Inventory",
+            description = "Shows a small colored box in the bottom right of the items in your inventory to display the paste it can be turned in to."
+    )
+    default boolean inventoryOverlay() {
+        return true;
+    }
+
+    @ConfigItem(
+            position = 2,
+            keyName = "bankOverlay",
+            name = "Herbs In Bank",
+            description = "Shows a small colored box  in the bottom right of the items in your bank to display the paste it can be turned in to."
+    )
+    default boolean bankOverlay() {
+        return true;
+    }
 }

--- a/src/main/java/com/geel/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/com/geel/masteringmixology/MasteringMixologyPlugin.java
@@ -2,6 +2,9 @@ package com.geel.masteringmixology;
 
 import com.geel.masteringmixology.enums.AlchemyPotion;
 import com.geel.masteringmixology.enums.AlchemyBuilding;
+import com.geel.masteringmixology.overlays.BankOverlay;
+import com.geel.masteringmixology.overlays.InventoryOverlay;
+import com.geel.masteringmixology.overlays.MixologyOverlay;
 import com.google.inject.Provides;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -52,6 +55,12 @@ public class MasteringMixologyPlugin extends Plugin {
     private MixologyOverlay overlay;
 
     @Inject
+    private InventoryOverlay inventoryOverlay;
+
+    @Inject
+    private BankOverlay bankOverlay;
+
+    @Inject
     private MixologyGameState mixologyGameState;
 
 
@@ -66,6 +75,8 @@ public class MasteringMixologyPlugin extends Plugin {
 //        clientThread.invoke(this::loadFromConfig);
         mixologyGameState.start();
         overlayManager.add(overlay);
+        overlayManager.add(inventoryOverlay);
+        overlayManager.add(bankOverlay);
     }
 
     @Override
@@ -74,6 +85,8 @@ public class MasteringMixologyPlugin extends Plugin {
 //        clientThread.invoke(this::resetParams);
         mixologyGameState.stop();
         overlayManager.remove(overlay);
+        overlayManager.remove(inventoryOverlay);
+        overlayManager.remove(bankOverlay);
     }
 
     @Subscribe

--- a/src/main/java/com/geel/masteringmixology/enums/HerbPastes.java
+++ b/src/main/java/com/geel/masteringmixology/enums/HerbPastes.java
@@ -1,0 +1,28 @@
+package com.geel.masteringmixology.enums;
+
+import java.awt.*;
+
+import java.util.Arrays;
+
+import lombok.AllArgsConstructor;
+
+import lombok.Getter;
+
+import static net.runelite.api.ItemID.*;
+
+@AllArgsConstructor
+public enum HerbPastes {
+    Mox("Mox Paste", new int[]{GUAM_LEAF, GUAM_POTION_UNF, MARRENTILL, MARRENTILL_POTION_UNF, TARROMIN, TARROMIN_POTION_UNF, HARRALANDER, HARRALANDER_POTION_UNF}, Color.decode("#584c87")),
+    Lye("Lye Paste", new int[]{RANARR_WEED, RANARR_POTION_UNF, TOADFLAX, TOADFLAX_POTION_UNF, AVANTOE, AVANTOE_POTION_UNF, KWUARM, KWUARM_POTION_UNF, SNAPDRAGON, SNAPDRAGON_POTION_UNF}, Color.PINK.darker()),
+    Aga("Aga Paste", new int[]{IRIT_LEAF, IRIT_POTION_UNF, HUASCA, HUASCA_POTION_UNF, CADANTINE, CADANTINE_POTION_UNF, DWARF_WEED, DWARF_WEED_POTION_UNF, TORSTOL, TORSTOL_POTION_UNF}, Color.GREEN.darker());
+
+
+    String name;
+    int[] herbIds;
+    @Getter
+    Color color;
+
+    public boolean CanItemBeUsedAsPaste(int itemId) {
+        return Arrays.stream(herbIds).anyMatch(x -> x == itemId);
+    }
+}

--- a/src/main/java/com/geel/masteringmixology/overlays/BankOverlay.java
+++ b/src/main/java/com/geel/masteringmixology/overlays/BankOverlay.java
@@ -22,13 +22,13 @@ public class BankOverlay extends Overlay {
     BankOverlay(Client client, MasteringMixologyConfig config) {
         this.client = client;
         this.config = config;
-        this.setLayer(OverlayLayer.ALWAYS_ON_TOP);
+        this.setLayer(OverlayLayer.ABOVE_WIDGETS);
     }
 
     @Override
     public Dimension render(Graphics2D graphics) {
         Widget bankWidget = client.getWidget(ComponentID.BANK_ITEM_CONTAINER);
-        if (bankWidget.isHidden() || !config.bankOverlay()) {
+        if (bankWidget == null || bankWidget.isHidden() || !config.bankOverlay()) {
             return null;
         }
 

--- a/src/main/java/com/geel/masteringmixology/overlays/BankOverlay.java
+++ b/src/main/java/com/geel/masteringmixology/overlays/BankOverlay.java
@@ -1,0 +1,56 @@
+package com.geel.masteringmixology.overlays;
+
+import com.geel.masteringmixology.MasteringMixologyConfig;
+import com.geel.masteringmixology.enums.HerbPastes;
+
+import java.awt.*;
+
+import javax.inject.Inject;
+
+import net.runelite.api.Client;
+import net.runelite.api.Point;
+import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+
+public class BankOverlay extends Overlay {
+    private final Client client;
+    private final MasteringMixologyConfig config;
+
+    @Inject
+    BankOverlay(Client client, MasteringMixologyConfig config) {
+        this.client = client;
+        this.config = config;
+        this.setLayer(OverlayLayer.ALWAYS_ON_TOP);
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        Widget bankWidget = client.getWidget(ComponentID.BANK_ITEM_CONTAINER);
+        if (bankWidget.isHidden() || !config.bankOverlay()) {
+            return null;
+        }
+
+        Widget[] dynamicChildren = bankWidget.getDynamicChildren();
+        for (int i = 0; i < dynamicChildren.length; i++) {
+            Widget widget = dynamicChildren[i];
+            int itemId = widget.getItemId();
+            if (itemId <= 0) {
+                continue;
+            }
+            for (HerbPastes herbPaste : HerbPastes.values()) {
+                if (herbPaste.CanItemBeUsedAsPaste(itemId)) {
+                    drawOverlay(graphics, widget, herbPaste.getColor());
+                }
+            }
+        }
+        return null;
+    }
+    private void drawOverlay(Graphics2D graphics, Widget widget, Color color) {
+        Point location = widget
+                .getCanvasLocation();
+        graphics.setColor(color);
+        graphics.fillRect(location.getX() + 15, location.getY(), 10, 10);
+    }
+}

--- a/src/main/java/com/geel/masteringmixology/overlays/InventoryOverlay.java
+++ b/src/main/java/com/geel/masteringmixology/overlays/InventoryOverlay.java
@@ -1,0 +1,67 @@
+package com.geel.masteringmixology.overlays;
+
+import com.geel.masteringmixology.MasteringMixologyConfig;
+
+import com.geel.masteringmixology.enums.HerbPastes;
+
+import java.awt.*;
+import javax.inject.Inject;
+
+import net.runelite.api.Client;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.Point;
+import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+
+public class InventoryOverlay extends Overlay {
+
+    private final Client client;
+    private final MasteringMixologyConfig config;
+
+    @Inject
+    public InventoryOverlay(Client client, MasteringMixologyConfig config) {
+        this.client = client;
+        this.config = config;
+        setPosition(OverlayPosition.DYNAMIC);
+        setLayer(OverlayLayer.ABOVE_WIDGETS);
+        setPriority(Overlay.PRIORITY_HIGH);
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        if (config.inventoryOverlay()) {
+            Widget inventoryWidget = client.getWidget(ComponentID.INVENTORY_CONTAINER);
+            if (inventoryWidget.isHidden()) {
+                inventoryWidget = client.getWidget(ComponentID.BANK_INVENTORY_ITEM_CONTAINER);
+                if (inventoryWidget.isHidden()) {
+                    return null;
+                }
+            }
+            Item[] items = client.getItemContainer(InventoryID.INVENTORY).getItems();
+            for (int i = 0; i < items.length; i++) {
+                Item item = items[i];
+                if (item == null) {
+                    continue;
+                }
+                for (HerbPastes herbPaste : HerbPastes.values()) {
+                    if (herbPaste.CanItemBeUsedAsPaste(item.getId())) {
+                        drawOverlay(graphics, inventoryWidget, i, herbPaste.getColor());
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private void drawOverlay(Graphics2D graphics, Widget inventoryWidget, int index, Color color) {
+        Point location = inventoryWidget
+                .getChild(index)
+                .getCanvasLocation();
+        graphics.setColor(color);
+        graphics.fillRect(location.getX() + 20, location.getY() + 20, 10, 10);
+    }
+}

--- a/src/main/java/com/geel/masteringmixology/overlays/MixologyOverlay.java
+++ b/src/main/java/com/geel/masteringmixology/overlays/MixologyOverlay.java
@@ -1,5 +1,7 @@
-package com.geel.masteringmixology;
+package com.geel.masteringmixology.overlays;
 
+import com.geel.masteringmixology.MasteringMixologyPlugin;
+import com.geel.masteringmixology.MixologyGameState;
 import com.geel.masteringmixology.enums.AlchemyContract;
 import com.geel.masteringmixology.enums.AlchemyPaste;
 import com.geel.masteringmixology.enums.AlchemyBuilding;
@@ -14,6 +16,7 @@ import javax.inject.Inject;
 import java.awt.*;
 
 @Slf4j
+public
 class MixologyOverlay extends Overlay {
     private final Client client;
     private final MixologyGameState gameState;


### PR DESCRIPTION
Adds overlays for inventory and bank like: [![Image from Gyazo](https://i.gyazo.com/7ab92c24a7715ef44aee7bcec2dad2ad.png)](https://gyazo.com/7ab92c24a7715ef44aee7bcec2dad2ad)
Showing each herb/pot's corresponding paste.